### PR TITLE
🔀: 다른모임 추천 페이지 스타일 수정

### DIFF
--- a/src/components/Main/atoms/Item/OtherClassFilterItem/style.ts
+++ b/src/components/Main/atoms/Item/OtherClassFilterItem/style.ts
@@ -1,19 +1,20 @@
-import styled from "@emotion/styled";
+import styled from '@emotion/styled'
 
 interface OtherClassFilterItemPropsType {
-    toColor:boolean
+  toColor: boolean
 }
 
 export const OtherClassFilterItem = styled.div<OtherClassFilterItemPropsType>`
-border-radius: 7px;
-background-color: ${(props)=>props.toColor?"#3355CD":"#fff"};
-color:${(props)=>props.toColor?"#F7F8FA":"#000000"};
-font-weight: 500;
-font-size: 16px;
-padding-top: 2vh;
-padding-bottom: 2vh;
-padding-left: 3.5vh;
-padding-right: 3.5vh;
-transition: left 0.5s;
-filter: drop-shadow(0px 0px 5px rgba(167, 167, 167, 0.25));
+  border-radius: 7px;
+  background-color: ${(props) => (props.toColor ? '#3355CD' : '#fff')};
+  color: ${(props) => (props.toColor ? '#F7F8FA' : '#000000')};
+  font-weight: 500;
+  font-size: 16px;
+  padding-top: 1.5vh;
+  padding-bottom: 1.5vh;
+  padding-left: 1.5vw;
+  padding-right: 1.5vw;
+  margin-right: 10px;
+  transition: left 0.5s;
+  filter: drop-shadow(0px 0px 5px rgba(167, 167, 167, 0.25));
 `

--- a/src/components/Main/atoms/Item/OtherClassItem/style.ts
+++ b/src/components/Main/atoms/Item/OtherClassItem/style.ts
@@ -5,15 +5,15 @@ export const OtherClassItemWrapper = styled.div`
   border-radius: 10px;
   fill: #fff;
   filter: drop-shadow(0px 0px 10px rgba(154, 154, 154, 0.25));
-  height: 23.5vh;
-  width: 58.5vh;
+  height: 170px;
+  width: 470px;
+  margin-left: 10px;
+  margin-right: 10px;
   background-color: #fff;
   display: flex;
   overflow: hidden;
   align-items: center;
   justify-content: center;
-  
-  
 `
 export const thumbnailWrapper = styled.div`
   overflow: hidden;
@@ -24,10 +24,9 @@ export const thumbnailWrapper = styled.div`
 export const TitleWrapper = styled.label`
   font-size: 20px;
   font-weight: 600;
- 
 `
 export const InformationWrapper = styled.div`
-margin-left: 1rem;
+  margin-left: 1rem;
   height: 70%;
   width: 53%;
   display: flex;
@@ -53,7 +52,7 @@ export const TagsLIstWrapper = styled.div`
   white-space: nowrap;
   flex-direction: row;
   ::-webkit-scrollbar {
-  display: none;
+    display: none;
   }
 `
 

--- a/src/components/Main/molecules/OtherClassFilter/style.ts
+++ b/src/components/Main/molecules/OtherClassFilter/style.ts
@@ -4,5 +4,5 @@ export const OtherClassFilterWrapper = styled.div`
   cursor: pointer;
   width: 64%;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
 `

--- a/src/components/Main/molecules/OtherClassList/style.ts
+++ b/src/components/Main/molecules/OtherClassList/style.ts
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled'
 
 export const OtherClassListWrapper = styled.div`
-margin-top:8vh ;
-  width: 56%;
+  margin-top: 50px;
+  margin-bottom: 50px;
+  width: 85%;
   display: flex;
-  justify-content: space-between;
   flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
   gap: 1.5rem 0rem;
 `

--- a/src/pages/main/otherClass/index.tsx
+++ b/src/pages/main/otherClass/index.tsx
@@ -1,10 +1,12 @@
 import OutherClass from '@/components/Main/organisms/OtherClass'
 import MainLayout from '../layout'
+import Header from '@/components/Common/organisms/Header'
 
 function OuterClass() {
   return (
     <>
       <MainLayout>
+        <Header />
         <OutherClass />
       </MainLayout>
     </>


### PR DESCRIPTION
## 💡 개요
다른모임 추천페이지을 반응형에 맞게 수정하였습니다
## 📃 작업내용
<img width="1263" alt="스크린샷 2023-09-20 오전 9 54 40" src="https://github.com/Team-Ezel/VOZA-client-v1/assets/103719872/51d34914-4efd-49b0-bd26-bde883ecaea1">

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
