### PR TITLE
🔀: 헤더 프로필사진 적용

### DIFF
--- a/src/components/Common/atoms/MenuItems/Profile/index.tsx
+++ b/src/components/Common/atoms/MenuItems/Profile/index.tsx
@@ -1,21 +1,49 @@
 import { Arrow_down, Arrow_up, Default_profile } from '@/assets/svgs'
 import * as S from './style'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
+import { accessToken } from '@/lib/token'
 
 interface ProfileProps {
   clicked: boolean
   setClicked: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const Profile : React.FC<ProfileProps> = ({ clicked, setClicked }) => {
+const Profile: React.FC<ProfileProps> = ({ clicked, setClicked }) => {
+  const baseurl: string | undefined = process.env.NEXT_PUBLIC_BASEURL
+  const [profileUrl, setProfileUrl] = useState<string>('')
+
+  const fetchData = async () => {
+    try {
+      const accessToken = localStorage.getItem('kakao-accessToken')
+
+      if (!accessToken) {
+        console.error('Access Token이 없습니다.')
+        return
+      }
+
+      const response = await axios.get(`${baseurl}/user/profile`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
+      setProfileUrl(response.data.profileUrl)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  useEffect(() => {
+    fetchData()
+  }, [accessToken])
 
   return (
     <S.ProfileWrapper>
-      <Default_profile width={38} height={38} />
+      <S.MemeberProfileImg ProfileImgURL={profileUrl} />
       <div onClick={() => setClicked(!clicked)}>
         {clicked ? <Arrow_up /> : <Arrow_down />}
       </div>
-    </S.ProfileWrapper >
+    </S.ProfileWrapper>
   )
 }
 

--- a/src/components/Common/atoms/MenuItems/Profile/index.tsx
+++ b/src/components/Common/atoms/MenuItems/Profile/index.tsx
@@ -3,6 +3,7 @@ import * as S from './style'
 import React, { useEffect, useState } from 'react'
 import axios from 'axios'
 import { accessToken } from '@/lib/token'
+import useFetch from '@/hooks/useFetch'
 
 interface ProfileProps {
   clicked: boolean
@@ -11,35 +12,23 @@ interface ProfileProps {
 
 const Profile: React.FC<ProfileProps> = ({ clicked, setClicked }) => {
   const baseurl: string | undefined = process.env.NEXT_PUBLIC_BASEURL
-  const [profileUrl, setProfileUrl] = useState<string>('')
 
-  const fetchData = async () => {
-    try {
-      const accessToken = localStorage.getItem('kakao-accessToken')
-
-      if (!accessToken) {
-        console.error('Access Token이 없습니다.')
-        return
-      }
-
-      const response = await axios.get(`${baseurl}/user/profile`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-      setProfileUrl(response.data.profileUrl)
-    } catch (error) {
-      console.error(error)
-    }
-  }
+  const { isLoading, fetch, data } = useFetch<{ profileUrl: string }>({
+    url: `${baseurl}/user/profile`,
+    method: 'GET',
+  })
 
   useEffect(() => {
-    fetchData()
-  }, [accessToken])
+    fetch()
+  }, [])
 
   return (
     <S.ProfileWrapper>
-      <S.MemeberProfileImg ProfileImgURL={profileUrl} />
+      {isLoading ? (
+        <Default_profile width={40} height={40} />
+      ) : (
+        <S.MemeberProfileImg ProfileImgURL={data?.profileUrl || ''} />
+      )}
       <div onClick={() => setClicked(!clicked)}>
         {clicked ? <Arrow_up /> : <Arrow_down />}
       </div>

--- a/src/components/Common/atoms/MenuItems/Profile/style.ts
+++ b/src/components/Common/atoms/MenuItems/Profile/style.ts
@@ -1,7 +1,18 @@
+import { ProfileURLPropsType } from '@/types/components/common/ProfileURLPropsType'
 import styled from '@emotion/styled'
 
 export const ProfileWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+`
+
+export const MemeberProfileImg = styled.div<ProfileURLPropsType>`
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  background-image: url(${(props) => props.ProfileImgURL});
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
 `

--- a/src/types/components/common/ProfileURLPropsType.ts
+++ b/src/types/components/common/ProfileURLPropsType.ts
@@ -1,0 +1,3 @@
+export type ProfileURLPropsType = {
+  ProfileImgURL: string
+}


### PR DESCRIPTION
## 💡 개요
헤더 프로필을 변경했습니다
## 📃 작업내용
<img width="1509" alt="스크린샷 2023-11-01 오후 12 05 24" src="https://github.com/Team-Ezel/VOZA-client-v1/assets/103719872/207a93ec-13c0-452b-99b0-4dba53f294fd">

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
