### PR TITLE
🔀 :  VOZA 로고 클릭시 /main으로 이동

### DIFF
--- a/src/components/Common/organisms/Header/index.tsx
+++ b/src/components/Common/organisms/Header/index.tsx
@@ -43,7 +43,7 @@ const Header = () => {
     <>
       <S.HeaderWrapper>
         <div className='block'>
-          <Link href={'/'}>
+          <Link href={'/main'}>
             <S.VozaLogo>
               <Logo />
             </S.VozaLogo>


### PR DESCRIPTION
## 💡 개요
 VOZA 로고 클릭시  프로모션페이지로 이동하던 것을 메인페이지로 이동하게 수정하였습니다
## 📃 작업내용 

## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
